### PR TITLE
*::Assets.pm uses File::Copy::Recursive, but not added as prereq

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -18,6 +18,7 @@ Module::Build->new(
     'Mojolicious'         => 4,
     'Hash::Merge::Simple' => 0.051,
     'YAML'                => 0,
+    'File::Copy::Recursive' => 0,
   },
   meta_merge => {
     resources => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ WriteMakefile
                    'Module::Load' => 0,
                    'Hash::Merge::Simple' => '0.051',
                    'Mojolicious' => 4,
+                   'File::Copy::Recursive' => 0,
                    'Carp' => 0
                  }
 )


### PR DESCRIPTION
Every module used, should be added to list of prerequesits.
